### PR TITLE
[#79] Tell about rebase in 'hit status'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The changelog is available [on GitHub][2].
 
 ### Unreleased: 0.1.0.0
 
-* [#63](https://github.com/kowainik/hit-on/issues/63):
+* [#63](https://github.com/kowainik/hit-on/issues/63),
+  [#79](https://github.com/kowainik/hit-on/issues/79):
   Implement `hit status` command with pretty output.
 * Bump up to GHC 8.6.5.
 * Bump up to `relude-0.5.0`.

--- a/hit-on.cabal
+++ b/hit-on.cabal
@@ -65,6 +65,7 @@ library
                      , github ^>= 0.20
                      , gitrev ^>= 1.3
                      , optparse-applicative ^>= 0.14
+                     , process ^>= 1.6
                      , relude ^>= 0.5
                      , shellmet >= 0.0.0
                      , text


### PR DESCRIPTION
Resolves #79

Here is how it looks like if rebase is in progress:

![Screenshot from 2019-07-25 22-22-26](https://user-images.githubusercontent.com/4276606/61882302-c9c30800-af2a-11e9-94be-389ee45f44da.png)

If not rebase, output is the same as before. Any suggestions regarding message text are appreciated :slightly_smiling_face: 