### PR TITLE
[#86] Better support for binary files in 'hit status'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The changelog is available [on GitHub][2].
 ### Unreleased: 0.1.0.0
 
 * [#63](https://github.com/kowainik/hit-on/issues/63),
-  [#79](https://github.com/kowainik/hit-on/issues/79):
+  [#79](https://github.com/kowainik/hit-on/issues/79),
+  [#86](https://github.com/kowainik/hit-on/issues/86):
   Implement `hit status` command with pretty output.
 * [#67](https://github.com/kowainik/hit-on/issues/67):
   Implement `hit stash` and `hit unstash` commands.

--- a/src/Hit/Git.hs
+++ b/src/Hit/Git.hs
@@ -114,6 +114,7 @@ runStash = do
     "git" ["add", "."]
     "git" ["stash"]
 
+-- | @hit unstash@ command: pop all saved changes.
 runUnstash :: IO ()
 runUnstash = "git" ["stash", "pop"]
 

--- a/src/Hit/Git/Status.hs
+++ b/src/Hit/Git/Status.hs
@@ -77,9 +77,27 @@ data DiffStat = DiffStat
     , diffStatSigns :: !Text  -- ^ + and - stats
     }
 
+{- | This command parses diff stats in the following format:
+
+@
+<filename> | <n> <pluses-and-minuses>
+@
+
+It also handles special case of binary files. Typical raw text returned by @git@
+can look like this:
+
+@
+ .foo.un~  | Bin 0 -> 523 bytes
+ README.md |   4 ++++
+ foo       |   1 +
+@
+-}
 parseDiffStat :: [Text] -> Maybe DiffStat
 parseDiffStat = \case
-    [diffStatFile, diffStatCount, diffStatSigns] -> Just DiffStat{..}
+    diffStatFile:diffStatCount:rest -> Just DiffStat
+        { diffStatSigns = unwords rest
+        , ..
+        }
     _ -> Nothing
 
 showPrettyDiff :: Text -> IO ()


### PR DESCRIPTION
Resolves #86

Just one more addition to `hit status` to handle binary files. Now it works properly!

![Screenshot from 2019-07-28 21-20-36](https://user-images.githubusercontent.com/4276606/62007270-076b9f00-b17e-11e9-98f6-3abbf45468b8.png)
