### PR TITLE
[#77] `hit clear` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog is available [on GitHub][2].
   Implement `hit status` command with pretty output.
 * [#67](https://github.com/kowainik/hit-on/issues/67):
   Implement `hit stash` and `hit unstash` commands.
+* [#77](https://github.com/kowainik/hit-on/issues/77):
+  Implement `hit clear` command.
 * [#81](https://github.com/kowainik/hit-on/issues/81):
   Implement `hit diff` command with pretty diff.
 * [#82](https://github.com/kowainik/hit-on/issues/82):

--- a/src/Hit/Cli.hs
+++ b/src/Hit/Cli.hs
@@ -15,9 +15,9 @@ import Options.Applicative (CommandFields, Mod, Parser, ParserInfo, argument, au
 
 import Hit.ColorTerminal (arrow, blueCode, boldCode, redCode, resetCode)
 import Hit.Core (CommitOptions (..), PushBool (..))
-import Hit.Git (getUsername, runAmend, runClone, runCommit, runCurrent, runDiff, runFix, runFresh,
-                runHop, runNew, runPush, runResolve, runStash, runStatus, runSync, runUncommit,
-                runUnstash)
+import Hit.Git (getUsername, runAmend, runClear, runClone, runCommit, runCurrent, runDiff, runFix,
+                runFresh, runHop, runNew, runPush, runResolve, runStash, runStatus, runSync,
+                runUncommit, runUnstash)
 import Hit.Issue (runIssue)
 
 import qualified Data.Text as T
@@ -41,6 +41,7 @@ hit = execParser cliParser >>= \case
     Resolve branchName -> runResolve branchName
     Push isForce -> runPush isForce
     Sync -> runSync
+    Clear isForce -> runClear isForce
     Current -> runCurrent >>= flip whenJust (flip runIssue Nothing . Just)
     Status commit -> runCurrent >> runStatus commit
     Diff commit -> runDiff commit
@@ -72,6 +73,7 @@ data HitCommand
     | Resolve (Maybe Text)
     | Push PushBool
     | Sync
+    | Clear PushBool
     | Current
     | Status (Maybe Text)
     | Diff (Maybe Text)
@@ -93,6 +95,7 @@ hitP = subparser
    <> com "push"     pushP     "Push the current branch"
    <> com "sync"     syncP     "Sync local branch with its remote"
    <> com "resolve"  resolveP  "Switch to master, sync and delete the branch"
+   <> com "clear"    clearP    "Remove all local changes permanently"
    <> com "current"  currentP  "Show info about current branch and issue (if applicable)"
    <> com "status"   statusP   "Show current branch and beautiful stats with COMMIT_HASH (by default HEAD)"
    <> com "diff"     diffP     "Display beautiful diff with COMMIT_HASH (by default HEAD)"
@@ -157,6 +160,9 @@ pushP = Push <$> pushBoolP
 
 syncP :: Parser HitCommand
 syncP = pure Sync
+
+clearP :: Parser HitCommand
+clearP = Clear <$> pushBoolP
 
 currentP :: Parser HitCommand
 currentP = pure Current

--- a/src/Hit/ColorTerminal.hs
+++ b/src/Hit/ColorTerminal.hs
@@ -29,6 +29,10 @@ module Hit.ColorTerminal
        , resetCode
        , blueBg
 
+         -- * Input with prompt
+       , Answer (..)
+       , prompt
+
        , arrow
        ) where
 
@@ -36,6 +40,8 @@ import System.Console.ANSI (Color (..), ColorIntensity (Dull, Vivid),
                             ConsoleIntensity (BoldIntensity), ConsoleLayer (Background, Foreground),
                             SGR (..), setSGR, setSGRCode)
 import System.IO (hFlush)
+
+import qualified Data.Text as T
 
 
 -- | Explicit flush ensures prompt messages are in the correct order on all systems.
@@ -105,3 +111,23 @@ mkColor color = toText $ setSGRCode [SetColor Foreground Vivid color]
 -- | Arrow symbol
 arrow :: Text
 arrow = " ➤  "
+
+-- | Represents a user's answer
+data Answer = Y | N
+
+-- | Parse an answer to 'Answer'
+yesOrNo :: Text -> Maybe Answer
+yesOrNo (T.toLower -> answer )
+    | T.null answer = Just Y
+    | answer `elem` ["yes", "y", "ys"] = Just Y
+    | answer `elem` ["no", "n"]  = Just N
+    | otherwise = Nothing
+
+prompt :: IO Answer
+prompt = do
+    answer <- yesOrNo . T.strip <$> getLine
+    case answer of
+        Just ans -> pure ans
+        Nothing -> do
+           errorMessage "This wasn't a valid choice."
+           prompt

--- a/src/Hit/Git/Status.hs
+++ b/src/Hit/Git/Status.hs
@@ -94,8 +94,10 @@ can look like this:
 -}
 parseDiffStat :: [Text] -> Maybe DiffStat
 parseDiffStat = \case
-    diffStatFile:diffStatCount:rest -> Just DiffStat
-        { diffStatSigns = unwords rest
+    [diffStatFile, diffStatCount, diffStatSigns] -> Just DiffStat{..}
+    diffStatFile:"Bin":rest -> Just DiffStat
+        { diffStatCount = "Bin"
+        , diffStatSigns = unwords rest
         , ..
         }
     _ -> Nothing


### PR DESCRIPTION
Resolves #77

It works. Any suggestions regarding text message are appreciated :slightly_smiling_face: 

Also, I think I got tired copy-pasting these terminal utils... Probably can create separate library `color-prompt` or something like that. But I don't know...

I also fixed `hit status` command (again). It doesn't always work...