### PR TITLE
Add support for building and installing with Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ cabal.project.local
 # Stack
 .stack-work/
 stack.yaml.lock
+# Nix
+result
 
 ### IDE/support
 # Vim

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ You need to follow these steps:
      ```shell
         stack install hit-on
      ```
+  * [Nix](https://nixos.org/nix/)
+    ```shell
+       nix-env -f . -i
+    ```
+
 4. Make sure that `hit` is installed:
 
     ```shell

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,31 @@
+{ # The git revision here corresponds to the nixpkgs-unstable channel, which at
+  # the time of this writing has GHC 8.6.5 as the default compiler (matching the
+  # one used by stack.yaml). Use https://howoldis.herokuapp.com/ to determine
+  # the current rev.
+  pkgs ? import (builtins.fetchTarball "https://github.com/nixos/nixpkgs/archive/002b853782e.tar.gz") {}
+  # Which GHC compiler to use.
+  # To determine the list of compilers available run:
+  #   nix-env -f "<nixpkgs>" -qaP -A haskell.compiler
+, compiler ? "default"
+}:
+let
+  haskellPackages =
+    if compiler == "default"
+      then pkgs.haskellPackages
+      else pkgs.haskell.packages.${compiler};
+in
+haskellPackages.developPackage {
+  # The path to our cabal project's root directory
+  root = ./.;
+
+  # Haskell packages to override
+  source-overrides = {
+    github = builtins.fetchTarball "https://github.com/phadej/github/archive/cdae698f50f9e6dc1b58d2181672294e2b11dfb3.tar.gz";
+    relude = builtins.fetchTarball "https://github.com/kowainik/relude/archive/55968311244690f5cc8b4484a37a63d988ea2ec4.tar.gz";
+    shellmet = builtins.fetchTarball "https://github.com/kowainik/shellmet/archive/36149eb0eb2b81916a93cdb92f3cb949d2eb9d23.tar.gz";
+  };
+
+  overrides = self: super: with pkgs.haskell.lib; {
+    github = dontCheck super.github;  # `dontCheck` skips running tests on this package
+  };
+}

--- a/hit-on.cabal
+++ b/hit-on.cabal
@@ -69,7 +69,7 @@ library
                      , optparse-applicative ^>= 0.14
                      , process ^>= 1.6
                      , relude ^>= 0.5
-                     , shellmet >= 0.0.0
+                     , shellmet >= 0.0.1
                      , text
                      , vector ^>= 0.12
 


### PR DESCRIPTION
I used `developPackage` (as [explained here](https://notes.srid.ca/haskell-nix)) to implement this.

With this PR, developers can run the following command while hacking on hit-on:

```shell
nix-shell --run 'ghcid -c "cabal new-repl"'
```

And users can run the following to install hit-on locally:

```shell
nix-env -f . -i
```
