### PR TITLE
[#41, #42] Add Linux/Mac installation instructions via Scarf

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ chmod +x hit-linux
 mv hit-linux ~/.local/bin/hit
 ```
 
+#### Install with Scarf
+
+On Linux and MacOS, you can install with [Scarf](https://scarf.sh/):
+
+```
+scarf install hit-on
+```
+
 #### Build from source
 
 > **NOTE:** the project is written in Haskell, so you need to have one of the Haskell build tools installed. See this [blog post](https://kowainik.github.io/posts/2018-06-21-haskell-build-tools) for installation and usage instructions.


### PR DESCRIPTION
Hello! I saw in #41 and #42 that installation via a package manager was an open issue. I have made `hit-on` installable via [Scarf](https://scarf.sh/package/scarf/hit-on) (disclaimer: I am the author of Scarf, another Haskell project 😄 ). I'd be happy to transfer package ownership to kowainik so you can see hit-on's usage information, manage the package, and if you're interested, charge companies when hit-on is used in a commercial setting.