### PR TITLE
[#104] Support renames in 'hit status'

### DIFF
--- a/src/Hit/Git.hs
+++ b/src/Hit/Git.hs
@@ -261,12 +261,11 @@ issueFromBranch =
     . T.drop 1
     . T.dropWhile (/= '/')
 
-
 {- | Perform the given action by first staging the given files and
 later removing them again after the action
 -}
-withFiles :: IO a -> IO [Text] -> ([Text] -> IO ()) -> IO a
-withFiles action whichFiles removeFiles = bracket
+withFiles :: IO [Text] -> IO a -> IO a
+withFiles whichFiles action = bracket
     addFiles
     removeFiles
     (const action)
@@ -277,32 +276,26 @@ withFiles action whichFiles removeFiles = bracket
         for_ files $ \file -> void $ "git" $| ["add", file]
         pure files
 
+    -- Return files back to not spoil git state and have unexpected behavior
+    removeFiles :: [Text] -> IO ()
+    removeFiles = mapM_ $ \file -> void $ "git" $| ["reset", "--", file]
+
 {- | Perform given action by adding all deleted files to index and returning
 them back after action.
 -}
 withDeletedFiles :: IO a -> IO a
-withDeletedFiles action = withFiles action deletedFiles removeDeletedFiles
+withDeletedFiles = withFiles deletedFiles
   where
     -- Find the deleted file to index so they will appear in diff
     deletedFiles :: IO [Text]
-    deletedFiles = lines <$> "git" $| ["ls-files", "-d", "--exclude-standard"]
-
-    -- Return deleted files back to not spoil git state and have unexpected behavior
-    removeDeletedFiles :: [Text] -> IO ()
-    removeDeletedFiles = mapM_ $ \file -> void $ "git" $| ["reset", "--", file]
+    deletedFiles = lines <$> "git" $| ["ls-files", "--deleted", "--exclude-standard"]
 
 {- | Perform given action by adding all untracked files to index and returning
 them back after action.
 -}
 withUntrackedFiles :: IO a -> IO a
-withUntrackedFiles action = withFiles action
-    untrackedFiles
-    removeUntrackedFiles
+withUntrackedFiles = withFiles untrackedFiles
   where
-    -- Add all untracked file to index so they will appear in diff
+    -- Find the untracked file to index so they will appear in diff
     untrackedFiles :: IO [Text]
     untrackedFiles = lines <$> "git" $| ["ls-files", "--others", "--exclude-standard"]
-
-    -- Return untracked files back to not spoil git state and have unexpected behavior
-    removeUntrackedFiles :: [Text] -> IO ()
-    removeUntrackedFiles = mapM_ $ \file -> void $ "git" $| ["reset", file]

--- a/src/Hit/Git/Status.hs
+++ b/src/Hit/Git/Status.hs
@@ -168,7 +168,7 @@ showPrettyDiff commit = do
         _ -> id
       where
         formatRename :: Text -> Text
-        formatRename = T.intercalate " -> " . T.words
+        formatRename = T.intercalate " -> " . words
 
     formatTableAligned :: [(Text, Text, Text, Text)] -> Text
     formatTableAligned rows = unlines $ map formatRow rows


### PR DESCRIPTION
Should solve #104.
Previously parsing renames failed because git adds a similarity percentage between the two files. 
Also, staging both the untracked and deleted files is necessary for git to 'see' that a file was renamed. 