### PR TITLE
Use Relude 0.6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 install:
   # HLint check
-  - curl https://raw.githubusercontent.com/kowainik/relude/55968311244690f5cc8b4484a37a63d988ea2ec4/.hlint.yaml -o .hlint-relude.yaml
+  - curl https://raw.githubusercontent.com/kowainik/relude/v0.6.0.0/.hlint.yaml -o .hlint-relude.yaml
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint -h .hlint-relude.yaml src/
   # install stack and build project
   - curl -sSL https://get.haskellstack.org/ | sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `hit-on` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+### Unreleased
+
+* Move to the newer `relude-0.6.0.0`.
+
 ### 0.1.0.0 — Aug 3, 2019
 
 * [#85](https://github.com/kowainik/hit-on/issues/85):

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: .
+
+tests: True
+
+source-repository-package
+    type: git
+    location: https://github.com/kowainik/relude
+    tag: 8b179dec16d13605a0fd007e56827cc369a4db14

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,0 @@
-packages: .
-
-tests: True
-
-source-repository-package
-    type: git
-    location: https://github.com/kowainik/relude
-    tag: 8b179dec16d13605a0fd007e56827cc369a4db14

--- a/hit-on.cabal
+++ b/hit-on.cabal
@@ -69,7 +69,7 @@ library
                      , gitrev ^>= 1.3
                      , optparse-applicative ^>= 0.14
                      , process ^>= 1.6
-                     , relude ^>= 0.5
+                     , relude ^>= 0.6.0.0
                      , shellmet >= 0.0.1
                      , text
                      , vector ^>= 0.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,8 @@ resolver: lts-14.7
 
 extra-deps:
   - github-0.23
-  - relude-0.5.0
   - shellmet-0.0.1
   - binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
+
+  - github: kowainik/relude
+    commit: 8b179dec16d13605a0fd007e56827cc369a4db14

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,6 @@ resolver: lts-14.7
 
 extra-deps:
   - github-0.23
+  - relude-0.6.0.0
   - shellmet-0.0.1
   - binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
-
-  - github: kowainik/relude
-    commit: 8b179dec16d13605a0fd007e56827cc369a4db14


### PR DESCRIPTION
Test before the release. No difficulties were found.