### PR TITLE
[#127] Assign users on `hit new --issue` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@
 `hit-on` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-### Unreleased
+### Unreleased: 0.2.0.0
 
-* Move to the newer `relude-0.6.0.0`.
+* [#65](https://github.com/kowainik/hit-on/issues/55):
+  Add `--issue` option to `hit new` command to create issue.
+  (by [@bangn](https://github.com/bangn)).
+* [#127](https://github.com/kowainik/hit-on/issues/127):
+  Assign user to issue on `hit new --issue` command.
+  (by [@chshersh](https://github.com/chshersh)).
+* [#125](https://github.com/kowainik/hit-on/pull/125):
+  Move to the newer `relude-0.6.0.0`.
+  (by [@vrom911](https://github.com/vrom911)).
 
 ### 0.1.0.0 — Aug 3, 2019
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,9 +1,9 @@
 module Main (main) where
 
-
-import System.IO (hSetEncoding, stdout, utf8)
+import System.IO (hSetEncoding, utf8)
 
 import Hit (hit)
+
 
 main :: IO ()
 main = hSetEncoding stdout utf8 >> hit

--- a/hit-on.cabal
+++ b/hit-on.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hit-on
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Haskell Git Helper Tool
 description:         Haskell Git Helper Tool
 homepage:            https://github.com/kowainik/hit-on
@@ -13,7 +13,7 @@ copyright:           2019 Kowainik
 category:            Git, CLI Tool
 build-type:          Simple
 extra-doc-files:     README.md
-                   , CHANGELOG.md
+                     CHANGELOG.md
 tested-with:         GHC == 8.6.5
 
 source-repository head
@@ -21,6 +21,12 @@ source-repository head
   location:            https://github.com/kowainik/hit-on.git
 
 common common-options
+  build-depends:       base ^>= 4.12.0.0
+                     , relude ^>= 0.6.0.0
+
+  mixins:              base hiding (Prelude)
+                     , relude (Relude as Prelude)
+
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
@@ -60,17 +66,14 @@ library
 
   autogen-modules:     Paths_hit_on
   other-modules:       Paths_hit_on
-                       Prelude
 
-  build-depends:       base-noprelude ^>= 4.12.0.0
-                     , ansi-terminal >= 0.8
+  build-depends:       ansi-terminal >= 0.8
                      , directory ^>= 1.3
                      , github ^>= 0.23
                      , gitrev ^>= 1.3
-                     , optparse-applicative ^>= 0.14
+                     , optparse-applicative ^>= 0.15
                      , process ^>= 1.6
-                     , relude ^>= 0.6.0.0
-                     , shellmet >= 0.0.1
+                     , shellmet ^>= 0.0.3.0
                      , text
                      , vector ^>= 0.12
 
@@ -78,15 +81,11 @@ executable hit
   import:              common-options
   hs-source-dirs:      app
   main-is:             Main.hs
+  build-depends:       hit-on
 
-  build-depends:       base ^>= 4.12.0.0
-                     , hit-on
-
-  ghc-options:         -Wall
-                       -threaded
+  ghc-options:         -threaded
                        -rtsopts
                        -with-rtsopts=-N
-
 
 test-suite hit-on-test
   import:              common-options
@@ -94,8 +93,7 @@ test-suite hit-on-test
   hs-source-dirs:      test
   main-is:             Main.hs
 
-  build-depends:       base
-                     , text
+  build-depends:       text
                      , hspec
                      , github
                      , hit-on

--- a/src/Hit/Cli.hs
+++ b/src/Hit/Cli.hs
@@ -60,7 +60,9 @@ cliParser = info ( helper <*> versionP <*> hitP )
 data HitCommand
     = Hop (Maybe Text)
     | Fresh (Maybe Text)
-    | New Bool Text
+    | New
+        Bool  -- ^ Should create issue as well?
+        Text  -- ^ Issue or branch name
     | Issue (Maybe Int) Bool
     | Stash
     | Unstash
@@ -114,9 +116,9 @@ freshP = Fresh <$> maybeBranchP
 newP :: Parser HitCommand
 newP = do
     createIssue <- switch
-                 $ long "issue"
-                 <> short 'i'
-                 <> help "Create new issue instead of branch"
+        $ long "issue"
+       <> short 'i'
+       <> help "Create new issue in addition to branch"
     issueNumOrBranch <- strArgument (metavar "ISSUE_NUMBER_OR_BRANCH_NAME")
     pure $ New createIssue issueNumOrBranch
 

--- a/src/Hit/Cli.hs
+++ b/src/Hit/Cli.hs
@@ -118,7 +118,7 @@ newP = do
     createIssue <- switch
         $ long "issue"
        <> short 'i'
-       <> help "Create new issue in addition to branch"
+       <> help "Create new issue in addition to branch and assign it to you"
     issueNumOrBranch <- strArgument (metavar "ISSUE_NUMBER_OR_BRANCH_NAME")
     pure $ New createIssue issueNumOrBranch
 

--- a/src/Hit/ColorTerminal.hs
+++ b/src/Hit/ColorTerminal.hs
@@ -111,7 +111,7 @@ mkColor color = toText $ setSGRCode [SetColor Foreground Vivid color]
 
 -- | Arrow symbol
 arrow :: Text
-arrow = " ➤  "
+arrow = " ➤ "
 
 -- | Represents a user's answer
 data Answer = Y | N

--- a/src/Hit/Git.hs
+++ b/src/Hit/Git.hs
@@ -81,7 +81,7 @@ mkBranchDescription Nothing issueOrName = case readMaybe @Int $ toString issueOr
 -}
 displayBranchDescription :: BranchDescription -> IO Text
 displayBranchDescription = \case
-    FromText text -> pure text
+    FromText text -> pure $ mkShortDesc text
     FromNewIssue issueNum issueTitle -> pure $ nameWithNumber issueNum issueTitle
     FromIssueNumber issueNum -> do
         issueTitle <- getIssueTitle $ mkIssueId issueNum

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -1,7 +1,0 @@
--- | Uses [relude](https://hackage.haskell.org/package/relude) as default Prelude.
-
-module Prelude
-       ( module Relude
-       ) where
-
-import Relude

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-14.7
 
 extra-deps:
   - github-0.23
+  - optparse-applicative-0.15.1.0
   - relude-0.6.0.0
-  - shellmet-0.0.1
+  - shellmet-0.0.3.0
   - binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613


### PR DESCRIPTION
Resolves #127

I've also done some refactoring regarding how we use `relude` and general `hit new` command (including some parts of the `Issue` module). I've tested the command, here is the example:

* https://github.com/kowainik/hit-off/issues/8

Now this command creates a new issue from the given description, assigned the user immediately and creates a new branch. You can see the example on the screenshot below:

![Screenshot from 2019-12-06 14-59-21](https://user-images.githubusercontent.com/4276606/70332256-130c5800-1839-11ea-813b-16fb884c43e8.png)

So, now it should be possible to do something like this to do fast coding and follow the workflow at the same time:

```shell
hit new --issue "Bump up to GHC-8.8.1"
```