### PR TITLE
[#68] Implement a prettier version for `git log`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ git config --global user.login <your_login>
  | status   | Show current branch and beautiful stats with COMMIT_HASH (by default HEAD) |
  | diff     | Display beautiful diff with COMMIT_HASH (by default HEAD)                  |
  | clone    | Clone the repo. Use 'reponame' or 'username/reponame' formats              |
+ | log      | Outputs the log of the current commit or COMMIT_HASH                       |
 
 ## Usage
 
@@ -376,6 +377,22 @@ With `hit` you can finish your work faster:
 
 ```shell
 hit resolve
+```
+
+### hit log
+
+Hooray, your PR just got merged! It's time to clean your local repository and start working on a new issue!
+
+With `git` you would do the following:
+
+```shell
+git log --oneline --decoratore [COMMIT_HASH]
+```
+
+With `hit` you can finish your work faster:
+
+```shell
+hit log [COMMIT_HASH]
 ```
 
 [git]: https://git-scm.com/

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Hooray, your PR just got merged! It's time to clean your local repository and st
 With `git` you would do the following:
 
 ```shell
-git log --oneline --decoratore [COMMIT_HASH]
+git log --oneline --decorate [COMMIT_HASH]
 ```
 
 With `hit` you can finish your work faster:

--- a/src/Hit/Cli.hs
+++ b/src/Hit/Cli.hs
@@ -17,7 +17,7 @@ import Hit.ColorTerminal (arrow, blueCode, boldCode, redCode, resetCode)
 import Hit.Core (CommitOptions (..), PushBool (..))
 import Hit.Git (getUsername, runAmend, runClear, runClone, runCommit, runCurrent, runDiff, runFix,
                 runFresh, runHop, runNew, runPush, runResolve, runStash, runStatus, runSync,
-                runUncommit, runUnstash)
+                runUncommit, runUnstash, runLog)
 import Hit.Issue (runIssue)
 
 import qualified Data.Text as T
@@ -46,6 +46,7 @@ hit = execParser cliParser >>= \case
     Status commit -> runCurrent >> runStatus commit
     Diff commit -> runDiff commit
     Clone name -> runClone name
+    Log commit -> runLog commit
 
 ----------------------------------------------------------------------------
 -- Parsers
@@ -81,6 +82,7 @@ data HitCommand
     | Status (Maybe Text)
     | Diff (Maybe Text)
     | Clone Text
+    | Log (Maybe Text)
 
 -- | Commands parser.
 hitP :: Parser HitCommand
@@ -103,6 +105,7 @@ hitP = subparser
    <> com "status"   statusP   "Show current branch and beautiful stats with COMMIT_HASH (by default HEAD)"
    <> com "diff"     diffP     "Display beautiful diff with COMMIT_HASH (by default HEAD)"
    <> com "clone"    cloneP    "Clone the repo. Use 'reponame' or 'username/reponame' formats"
+   <> com "log"      logP      "Display the log of the current commit or COMMIT_HASH"
   where
     com :: String -> Parser HitCommand -> String -> Mod CommandFields HitCommand
     com name p desc = command name (info (helper <*> p) $ progDesc desc)
@@ -192,6 +195,9 @@ resolveP = Resolve <$> maybeBranchP
 
 cloneP :: Parser HitCommand
 cloneP = Clone <$> strArgument (metavar "REPOSITORY")
+
+logP :: Parser HitCommand
+logP = Log <$> maybeCommitP
 
 -- | Parse optional branch name as an argument.
 maybeBranchP :: Parser (Maybe Text)

--- a/src/Hit/Git.hs
+++ b/src/Hit/Git.hs
@@ -20,6 +20,7 @@ module Hit.Git
        , runStatus
        , runDiff
        , runClone
+       , runLog
 
        , getUsername
        ) where
@@ -280,6 +281,9 @@ runClone txt = do
     let gitLink = "git@github.com:" <> name <> ".git"
     "git" ["clone", gitLink]
 
+runLog :: Maybe Text -> IO ()
+runLog (fromMaybe "HEAD" -> commit)
+    = "git" ["log", "--oneline", "--decorate", commit]
 ----------------------------------------------------------------------------
 -- Internal helpers
 ----------------------------------------------------------------------------


### PR DESCRIPTION
I'm just doing `git log --oneline --decorate` right now as I don't know
what to do show and it's better than nothing at least :)

closes #68